### PR TITLE
Automatic update of Microsoft.Extensions.Logging.Abstractions to 7.0.0

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.Core/HomeBudget.Core.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.Core/HomeBudget.Core.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.80" />
   </ItemGroup>

--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.Extensions.Logging.Abstractions` to `7.0.0` from `6.0.0`
`Microsoft.Extensions.Logging.Abstractions 7.0.0` was published at `2022-11-07T17:54:56Z`, 2 months ago

2 project updates:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.Core/HomeBudget.Core.csproj` to `Microsoft.Extensions.Logging.Abstractions` `7.0.0` from `6.0.0`
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj` to `Microsoft.Extensions.Logging.Abstractions` `7.0.0` from `6.0.0`

[Microsoft.Extensions.Logging.Abstractions 7.0.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/7.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
