### PR TITLE
Automatic update of AutoMapper to 12.0.1

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates.Tests/HomeBudget.Components.CurrencyRates.Tests.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates.Tests/HomeBudget.Components.CurrencyRates.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.0" />
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.0" />
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="MediatR" Version="11.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `AutoMapper` to `12.0.1` from `12.0.0`
`AutoMapper 12.0.1` was published at `2023-01-16T15:44:23Z`, 12 days ago

2 project updates:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `AutoMapper` `12.0.1` from `12.0.0`
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates.Tests/HomeBudget.Components.CurrencyRates.Tests.csproj` to `AutoMapper` `12.0.1` from `12.0.0`

[AutoMapper 12.0.1 on NuGet.org](https://www.nuget.org/packages/AutoMapper/12.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
