### PR TITLE
Automatic update of Microsoft.Data.SqlClient to 5.1.0

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.Data.SqlClient` to `5.1.0` from `5.0.1`
`Microsoft.Data.SqlClient 5.1.0` was published at `2023-01-19T21:11:55Z`, 9 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj` to `Microsoft.Data.SqlClient` `5.1.0` from `5.0.1`

[Microsoft.Data.SqlClient 5.1.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Data.SqlClient/5.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
