### PR TITLE
Automatic update of Serilog.Sinks.Elasticsearch to 9.0.0

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1" />
+    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="9.0.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.90" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a major update of `Serilog.Sinks.Elasticsearch` to `9.0.0` from `8.4.1`
`Serilog.Sinks.Elasticsearch 9.0.0` was published at `2023-02-02T08:51:47Z`, 9 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj` to `Serilog.Sinks.Elasticsearch` `9.0.0` from `8.4.1`

[Serilog.Sinks.Elasticsearch 9.0.0 on NuGet.org](https://www.nuget.org/packages/Serilog.Sinks.Elasticsearch/9.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
