### PR TITLE
Automatic update of Microsoft.VisualStudio.Azure.Containers.Tools.Targets to 1.18.1

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.4.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
     <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` to `1.18.1` from `1.17.0`
`Microsoft.VisualStudio.Azure.Containers.Tools.Targets 1.18.1` was published at `2023-02-25T00:36:21Z`, 2 months ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj` to `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` `1.18.1` from `1.17.0`

[Microsoft.VisualStudio.Azure.Containers.Tools.Targets 1.18.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.VisualStudio.Azure.Containers.Tools.Targets/1.18.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
