### PR TITLE
Automatic update of FluentValidation.DependencyInjectionExtensions to 11.5.2

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="6.0.5" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.4.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `FluentValidation.DependencyInjectionExtensions` to `11.5.2` from `11.4.0`
`FluentValidation.DependencyInjectionExtensions 11.5.2` was published at `2023-04-07T18:07:43Z`, 8 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj` to `FluentValidation.DependencyInjectionExtensions` `11.5.2` from `11.4.0`

[FluentValidation.DependencyInjectionExtensions 11.5.2 on NuGet.org](https://www.nuget.org/packages/FluentValidation.DependencyInjectionExtensions/11.5.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
