### PR TITLE
Automatic update of Microsoft.Data.SqlClient to 5.1.1

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Data.SqlClient` to `5.1.1` from `5.1.0`
`Microsoft.Data.SqlClient 5.1.1` was published at `2023-03-28T22:26:40Z`, 18 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj` to `Microsoft.Data.SqlClient` `5.1.1` from `5.1.0`

[Microsoft.Data.SqlClient 5.1.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.Data.SqlClient/5.1.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
