### PR TITLE
Automatic update of NUnit3TestAdapter to 4.5.0

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates.Tests/HomeBudget.Components.CurrencyRates.Tests.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates.Tests/HomeBudget.Components.CurrencyRates.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
 
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2">
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NUnit3TestAdapter` to `4.5.0` from `4.4.2`
`NUnit3TestAdapter 4.5.0` was published at `2023-05-30T18:30:18Z`, 11 days ago

2 project updates:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj` to `NUnit3TestAdapter` `4.5.0` from `4.4.2`
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates.Tests/HomeBudget.Components.CurrencyRates.Tests.csproj` to `NUnit3TestAdapter` `4.5.0` from `4.4.2`

[NUnit3TestAdapter 4.5.0 on NuGet.org](https://www.nuget.org/packages/NUnit3TestAdapter/4.5.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
