### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 9.3.0.71466

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/Directory.Build.props
+++ b/WebApi-app/HomeBudget-Web-API/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.0.0.68202" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.3.0.71466" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `9.3.0.71466` from `9.0.0.68202`
`SonarAnalyzer.CSharp 9.3.0.71466` was published at `2023-06-06T12:17:10Z`, 8 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/Directory.Build.props` to `SonarAnalyzer.CSharp` `9.3.0.71466` from `9.0.0.68202`

[SonarAnalyzer.CSharp 9.3.0.71466 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.3.0.71466)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
