### PR TITLE
Automatic update of Serilog.Sinks.Elasticsearch to 9.0.3

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="9.0.2" />
+    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="9.0.3" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.116" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Serilog.Sinks.Elasticsearch` to `9.0.3` from `9.0.2`
`Serilog.Sinks.Elasticsearch 9.0.3` was published at `2023-06-16T07:07:17Z`, 8 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj` to `Serilog.Sinks.Elasticsearch` `9.0.3` from `9.0.2`

[Serilog.Sinks.Elasticsearch 9.0.3 on NuGet.org](https://www.nuget.org/packages/Serilog.Sinks.Elasticsearch/9.0.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
