### PR TITLE
Automatic update of Datadog.Trace.Bundle to 2.32.0

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.5" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="6.0.5" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.31.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.32.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Datadog.Trace.Bundle` to `2.32.0` from `2.31.0`
`Datadog.Trace.Bundle 2.32.0` was published at `2023-06-20T08:11:25Z`, 11 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj` to `Datadog.Trace.Bundle` `2.32.0` from `2.31.0`

[Datadog.Trace.Bundle 2.32.0 on NuGet.org](https://www.nuget.org/packages/Datadog.Trace.Bundle/2.32.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
