### PR TITLE
Automatic update of Microsoft.AspNetCore.Mvc.Testing to 7.0.8

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.5" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="6.0.5" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.31.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.32.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />

--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.8" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="Moq" Version="4.18.4" />

--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.138" />
+    <PackageReference Include="Dapper" Version="2.0.143" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNetCore.Mvc.Testing` to `7.0.8` from `7.0.7`
`Microsoft.AspNetCore.Mvc.Testing 7.0.8` was published at `2023-06-22T18:02:55Z`, 9 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj` to `Microsoft.AspNetCore.Mvc.Testing` `7.0.8` from `7.0.7`

[Microsoft.AspNetCore.Mvc.Testing 7.0.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Testing/7.0.8)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
