### PR TITLE
Automatic update of Microsoft.Extensions.Http.Polly to 7.0.8

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="MediatR" Version="12.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.8" />
     <PackageReference Include="Polly" Version="7.2.4" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Refit" Version="6.3.2" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Extensions.Http.Polly` to `7.0.8` from `7.0.7`
`Microsoft.Extensions.Http.Polly 7.0.8` was published at `2023-06-22T18:03:45Z`, 9 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Microsoft.Extensions.Http.Polly` `7.0.8` from `7.0.7`

[Microsoft.Extensions.Http.Polly 7.0.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Http.Polly/7.0.8)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
