### PR TITLE
Automatic update of Refit.HttpClientFactory to 7.0.0

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Polly" Version="7.2.4" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Refit" Version="6.3.2" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />
     <PackageReference Include="Refit.Newtonsoft.Json" Version="6.3.2" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a major update of `Refit.HttpClientFactory` to `7.0.0` from `6.3.2`
`Refit.HttpClientFactory 7.0.0` was published at `2023-06-29T18:44:10Z`, 9 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Refit.HttpClientFactory` `7.0.0` from `6.3.2`

[Refit.HttpClientFactory 7.0.0 on NuGet.org](https://www.nuget.org/packages/Refit.HttpClientFactory/7.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
