### PR TITLE
Automatic update of Refit.Newtonsoft.Json to 7.0.0

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -12,9 +12,9 @@
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.7" />
     <PackageReference Include="Polly" Version="7.2.4" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-    <PackageReference Include="Refit" Version="6.3.2" />
+    <PackageReference Include="Refit" Version="7.0.0" />
     <PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
-    <PackageReference Include="Refit.Newtonsoft.Json" Version="6.3.2" />
+    <PackageReference Include="Refit.Newtonsoft.Json" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a major update of `Refit.Newtonsoft.Json` to `7.0.0` from `6.3.2`
`Refit.Newtonsoft.Json 7.0.0` was published at `2023-06-29T18:44:11Z`, 9 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Refit.Newtonsoft.Json` `7.0.0` from `6.3.2`

[Refit.Newtonsoft.Json 7.0.0 on NuGet.org](https://www.nuget.org/packages/Refit.Newtonsoft.Json/7.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
