### PR TITLE
Automatic update of StackExchange.Redis to 2.6.122

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="9.0.2" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.116" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.122" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.Core/HomeBudget.Core.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.Core/HomeBudget.Core.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.116" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.122" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `StackExchange.Redis` to `2.6.122` from `2.6.116`
`StackExchange.Redis 2.6.122` was published at `2023-07-07T14:55:56Z`, 8 days ago

2 project updates:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.Core/HomeBudget.Core.csproj` to `StackExchange.Redis` `2.6.122` from `2.6.116`
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj` to `StackExchange.Redis` `2.6.122` from `2.6.116`

[StackExchange.Redis 2.6.122 on NuGet.org](https://www.nuget.org/packages/StackExchange.Redis/2.6.122)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
