### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 9.6.0.74858

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/Directory.Build.props
+++ b/WebApi-app/HomeBudget-Web-API/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.5.0.73987" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.6.0.74858" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `9.6.0.74858` from `9.5.0.73987`
`SonarAnalyzer.CSharp 9.6.0.74858` was published at `2023-07-25T15:01:15Z`, 7 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/Directory.Build.props` to `SonarAnalyzer.CSharp` `9.6.0.74858` from `9.5.0.73987`

[SonarAnalyzer.CSharp 9.6.0.74858 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.6.0.74858)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
