### PR TITLE
Automatic update of Microsoft.VisualStudio.Azure.Containers.Tools.Targets to 1.19.5

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Datadog.Trace.Bundle" Version="2.35.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.6.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
     <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` to `1.19.5` from `1.18.1`
`Microsoft.VisualStudio.Azure.Containers.Tools.Targets 1.19.5` was published at `2023-07-26T01:42:11Z`, 15 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj` to `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` `1.19.5` from `1.18.1`

[Microsoft.VisualStudio.Azure.Containers.Tools.Targets 1.19.5 on NuGet.org](https://www.nuget.org/packages/Microsoft.VisualStudio.Azure.Containers.Tools.Targets/1.19.5)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
