### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 9.7.0.75501

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/Directory.Build.props
+++ b/WebApi-app/HomeBudget-Web-API/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.6.0.74858" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.7.0.75501" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `9.7.0.75501` from `9.6.0.74858`
`SonarAnalyzer.CSharp 9.7.0.75501` was published at `2023-08-04T14:58:37Z`, 7 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/Directory.Build.props` to `SonarAnalyzer.CSharp` `9.7.0.75501` from `9.6.0.74858`

[SonarAnalyzer.CSharp 9.7.0.75501 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.7.0.75501)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
