### PR TITLE
Automatic update of AspNetCore.HealthChecks.UI.Client to 7.1.0

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="7.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="7.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="7.0.1" />
-    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="7.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="7.1.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="7.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Datadog.Trace.Bundle" Version="2.35.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `AspNetCore.HealthChecks.UI.Client` to `7.1.0` from `7.0.0`
`AspNetCore.HealthChecks.UI.Client 7.1.0` was published at `2023-08-08T21:13:09Z`, 11 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj` to `AspNetCore.HealthChecks.UI.Client` `7.1.0` from `7.0.0`

[AspNetCore.HealthChecks.UI.Client 7.1.0 on NuGet.org](https://www.nuget.org/packages/AspNetCore.HealthChecks.UI.Client/7.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
