### PR TITLE
Automatic update of FluentValidation.DependencyInjectionExtensions to 11.7.1

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Datadog.Trace.Bundle" Version="2.35.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.6.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `FluentValidation.DependencyInjectionExtensions` to `11.7.1` from `11.6.0`
`FluentValidation.DependencyInjectionExtensions 11.7.1` was published at `2023-08-12T19:35:05Z`, 7 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj` to `FluentValidation.DependencyInjectionExtensions` `11.7.1` from `11.6.0`

[FluentValidation.DependencyInjectionExtensions 11.7.1 on NuGet.org](https://www.nuget.org/packages/FluentValidation.DependencyInjectionExtensions/11.7.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
