### PR TITLE
Automatic update of Microsoft.Extensions.Http.Polly to 7.0.10

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="MediatR" Version="12.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.10" />
     <PackageReference Include="Polly" Version="7.2.4" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Refit.Newtonsoft.Json" Version="7.0.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Extensions.Http.Polly` to `7.0.10` from `7.0.9`
`Microsoft.Extensions.Http.Polly 7.0.10` was published at `2023-08-08T12:15:02Z`, 11 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Microsoft.Extensions.Http.Polly` `7.0.10` from `7.0.9`

[Microsoft.Extensions.Http.Polly 7.0.10 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Http.Polly/7.0.10)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
