### PR TITLE
Automatic update of Microsoft.AspNetCore.Mvc.Testing to 7.0.10

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.10" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageReference Include="Moq" Version="4.18.4" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNetCore.Mvc.Testing` to `7.0.10` from `7.0.9`
`Microsoft.AspNetCore.Mvc.Testing 7.0.10` was published at `2023-08-08T12:14:12Z`, 11 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj` to `Microsoft.AspNetCore.Mvc.Testing` `7.0.10` from `7.0.9`

[Microsoft.AspNetCore.Mvc.Testing 7.0.10 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Testing/7.0.10)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
