### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 17.7.1

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates.Tests/HomeBudget.Components.CurrencyRates.Tests.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates.Tests/HomeBudget.Components.CurrencyRates.Tests.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.10" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.NET.Test.Sdk` to `17.7.1` from `17.7.0`
`Microsoft.NET.Test.Sdk 17.7.1` was published at `2023-08-16T14:35:47Z`, 7 days ago

2 project updates:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates.Tests/HomeBudget.Components.CurrencyRates.Tests.csproj` to `Microsoft.NET.Test.Sdk` `17.7.1` from `17.7.0`
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.Components.IntegrationTests/HomeBudget.Components.IntegrationTests.csproj` to `Microsoft.NET.Test.Sdk` `17.7.1` from `17.7.0`

[Microsoft.NET.Test.Sdk 17.7.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/17.7.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
