### PR TITLE
Automatic update of Dapper to 2.0.151

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.143" />
+    <PackageReference Include="Dapper" Version="2.0.151" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Dapper` to `2.0.151` from `2.0.143`
`Dapper 2.0.151` was published at `2023-08-18T09:46:06Z`, 7 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.DataAccess.Dapper/HomeBudget.DataAccess.Dapper.csproj` to `Dapper` `2.0.151` from `2.0.143`

[Dapper 2.0.151 on NuGet.org](https://www.nuget.org/packages/Dapper/2.0.151)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
