### PR TITLE
Automatic update of Datadog.Trace.Bundle to 2.37.0

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="7.1.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="7.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.35.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.37.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Datadog.Trace.Bundle` to `2.37.0` from `2.35.0`
`Datadog.Trace.Bundle 2.37.0` was published at `2023-08-31T07:49:02Z`, 9 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj` to `Datadog.Trace.Bundle` `2.37.0` from `2.35.0`

[Datadog.Trace.Bundle 2.37.0 on NuGet.org](https://www.nuget.org/packages/Datadog.Trace.Bundle/2.37.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
