### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 9.9.0.77355

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/Directory.Build.props
+++ b/WebApi-app/HomeBudget-Web-API/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.8.0.76515" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.9.0.77355" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `9.9.0.77355` from `9.8.0.76515`
`SonarAnalyzer.CSharp 9.9.0.77355` was published at `2023-09-04T14:25:47Z`, 8 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/Directory.Build.props` to `SonarAnalyzer.CSharp` `9.9.0.77355` from `9.8.0.76515`

[SonarAnalyzer.CSharp 9.9.0.77355 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.9.0.77355)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
