### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 9.10.0.77988

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/Directory.Build.props
+++ b/WebApi-app/HomeBudget-Web-API/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.9.0.77355" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.10.0.77988" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `9.10.0.77988` from `9.9.0.77355`
`SonarAnalyzer.CSharp 9.10.0.77988` was published at `2023-09-15T15:37:30Z`, 8 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/Directory.Build.props` to `SonarAnalyzer.CSharp` `9.10.0.77988` from `9.9.0.77355`

[SonarAnalyzer.CSharp 9.10.0.77988 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.10.0.77988)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
