### PR TITLE
Automatic update of AspNetCore.HealthChecks.Redis to 7.0.1

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="7.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="7.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="7.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI" Version="7.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="7.1.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `AspNetCore.HealthChecks.Redis` to `7.0.1` from `7.0.0`
`AspNetCore.HealthChecks.Redis 7.0.1` was published at `2023-09-14T09:43:32Z`, 9 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj` to `AspNetCore.HealthChecks.Redis` `7.0.1` from `7.0.0`

[AspNetCore.HealthChecks.Redis 7.0.1 on NuGet.org](https://www.nuget.org/packages/AspNetCore.HealthChecks.Redis/7.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
