### PR TITLE
Automatic update of Polly to 8.0.0

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj
@@ -11,7 +11,7 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.10" />
-		<PackageReference Include="Polly" Version="7.2.4" />
+		<PackageReference Include="Polly" Version="8.0.0" />
 		<PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
 		<PackageReference Include="Refit.Newtonsoft.Json" Version="7.0.0" />
 		<PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />


### PR DESCRIPTION
NuKeeper has generated a major update of `Polly` to `8.0.0` from `7.2.4`
`Polly 8.0.0` was published at `2023-09-28T10:49:26Z`, 7 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget.Components.CurrencyRates/HomeBudget.Components.CurrencyRates.csproj` to `Polly` `8.0.0` from `7.2.4`

[Polly 8.0.0 on NuGet.org](https://www.nuget.org/packages/Polly/8.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
