### PR TITLE
Automatic update of Serilog.Enrichers.Environment to 2.3.0

### DIFF
--- a/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
+++ b/WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Serilog.Enrichers.Environment` to `2.3.0` from `2.2.0`
`Serilog.Enrichers.Environment 2.3.0` was published at `2023-10-03T05:58:34Z`, 8 days ago

1 project update:
Updated `WebApi-app/HomeBudget-Web-API/HomeBudget-Web-API/HomeBudget-Web-API.csproj` to `Serilog.Enrichers.Environment` `2.3.0` from `2.2.0`

[Serilog.Enrichers.Environment 2.3.0 on NuGet.org](https://www.nuget.org/packages/Serilog.Enrichers.Environment/2.3.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
